### PR TITLE
allow user to fix kernel parameters

### DIFF
--- a/gpflowSlim/params.py
+++ b/gpflowSlim/params.py
@@ -140,7 +140,9 @@ class Parameter(object):
 
         # init var
         vf_value = self.transform.backward(value)
-        self.vf_val = tf.get_variable(self.instance_name, initializer=tf.cast(vf_value, settings.float_type))
+        self.vf_val = tf.get_variable(self.instance_name,
+                                      initializer=tf.cast(vf_value, settings.float_type),
+                                      trainable=self.trainable)
 
     @property
     def name(self):


### PR DESCRIPTION
Enable `Gpflow-Slim.Parameter` to set `trainable=False` when creating `tf.Variables`. 

In this way when user which to train a GP model with kernel parameters fixed, they can simply do something like
 `self._ls = Parameter(..., trainable=False)`